### PR TITLE
check dup before running highlight app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,4 +30,9 @@ Imports:
     stringr,
     httr,
     clipr,
-    shiny
+    shiny,
+    xml2,
+    commonmark,
+    fs,
+    purrr
+    

--- a/R/dup.R
+++ b/R/dup.R
@@ -1,0 +1,45 @@
+
+acceptable_dups <- function() {
+  c("http://developer.r-project.org/blosxom.cgi/R-devel/NEWS")
+}
+
+
+get_links <- function(path){
+  path %>%
+    readLines(warn = FALSE) %>%
+    .[1:which(grepl("Upcoming Events", .))] %>%
+    commonmark::markdown_xml() %>%
+    xml2::read_xml() %>%
+    xml2::xml_ns_strip() %>%
+    xml2::xml_find_all(xpath = './/link') %>%
+    xml2::xml_attr("destination")
+}
+
+get_dups <- function(rweekly_path = getwd()){
+  old_posts <- fs::dir_ls(file.path(
+    rweekly_path,"_posts"))
+  
+  old_posts <- old_posts[(length(old_posts) - 20):length(old_posts)]
+  
+  
+  old_links <- unlist(purrr::map(old_posts, get_links))
+  
+  thisweek <- get_links(file.path(rweekly_path,
+                                  "draft.md"))
+  current_dups <- thisweek[duplicated(thisweek)]
+  if (length(current_dups)) {
+    message("Duplicates found in current week:")
+    cat(paste0(current_dups, collapse = "\n"))
+    cat("\n")
+  }
+  
+  dups <- thisweek[thisweek %in% old_links]
+  dups <- setdiff(dups, acceptable_dups())
+  
+  if (length(dups) == 0) {
+    message("No duplicate links, well done! :-)")
+    return(c())
+  } else {
+    return(dups)
+  }
+}

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -30,7 +30,17 @@ run_app <- function() {
               Install it via install.packages('stringr')")
     return(NULL)
   }
-
+  
+  cur_path <- file.path(getwd(), "draft.md")
+  if (file.exists(cur_path)) {
+    dups <- get_dups()
+    if (length(dups)) {
+      warning('find dups')
+      print(dups)
+      invisible(return(NULL))
+    }
+  }
+  
   shiny::shinyApp(ui = highlight_ui, server = highlight_server)
 }
 
@@ -59,10 +69,15 @@ highlight_ui <- navbarPage(
 
 
 highlight_server <- function(input, output, session) {
-  
-  # Fetch draft
-  draft <- httr::GET("https://raw.githubusercontent.com/rweekly/rweekly.org/gh-pages/draft.md") %>%
-    httr::content("text")
+  cur_path <- file.path(getwd(), 'draft.md')
+  if (file.exists(cur_path)) {
+    draft <- paste(readLines(cur_path), sep = '\n', collapse = '\n')
+  } else {
+    warning('using the remote draft, skip checking dup links. Run this function in the folder with the draft to check duplicated items')
+    # Fetch draft
+    draft <- httr::GET("https://raw.githubusercontent.com/rweekly/rweekly.org/gh-pages/draft.md") %>%
+      httr::content("text")
+  }
   
   # Obtain Issue number
   issue <- (draft %>% stringr::str_match("title:\\s(.+)\\n"))[,2]


### PR DESCRIPTION
Support run `rweekly.highlights::run_app()` in the currernt path with `draft.md` to check duplicates.

if `draft.md` is missing, use the remote github version `draft.md` and skip checking duplicates.