### PR TITLE
Update acceptable duplicate links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rweekly.highlights
 Title: Creates the Weekly Highlights Poll Slack Text.
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     c(person(given = "Qin Wenfeng",
              role = c("aut", "cre"),
@@ -16,7 +16,12 @@ Authors@R:
              email = "haozhu233@gmail.com"),
       person(given = "Jon",
              family = "Calder",
-             role = "ctb"))
+             role = "ctb"),
+      persion(given = "Eric",
+              family = "Nantz",
+              role = "ctb",
+              email = "theRcast@gmail.com")
+      )
 Description: The app started by `run_app()` lets you pick up up to 10 links from the current R Weekly draft, to be voted upon by R Weekly editors. The app outputs the text to be pasted in the '#highlights' Slack channel.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,4 @@
+# rweekly.highlights (development version)
+
+* Update acceptable duplicate links to match script in RWeekly GitHub repository script
+* Add toggle for running duplicate checks in `run_app()`, in case duplicate checks have been performed already by another process.

--- a/R/dup.R
+++ b/R/dup.R
@@ -1,6 +1,10 @@
 
 acceptable_dups <- function() {
-  c("http://developer.r-project.org/blosxom.cgi/R-devel/NEWS")
+  c("http://developer.r-project.org/blosxom.cgi/R-devel/NEWS",
+    "https://github.com/rweekly/rweekly.org#how-to-have-my-content-shared-by-r-weekly",
+    "https://r-universe.dev/search/",
+    "https://rweekly.fireside.fm/",
+    "https://serve.podhome.fm/r-weekly-highlights")
 }
 
 

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -12,7 +12,7 @@
 #' run_app()
 #' }
 #' @export
-run_app <- function() {
+run_app <- function(check_dups = TRUE) {
   if (!requireNamespace("shiny", quietly = TRUE)) {
     message("run_app needs the shiny package, \n
               Install it via install.packages('shiny')")
@@ -30,9 +30,8 @@ run_app <- function() {
               Install it via install.packages('stringr')")
     return(NULL)
   }
-
   cur_path <- file.path(getwd(), "draft.md")
-  if (file.exists(cur_path)) {
+  if (file.exists(cur_path) & check_dups) {
     dups <- get_dups()
     if (length(dups)) {
       warning('find dups')


### PR DESCRIPTION
This PR updates the acceptable duplicate links used in the duplicate links analysis. Also I added a toggle for executing the duplicate checks in the `run_app()` function in case the duplicate analysis has been performed already locally.